### PR TITLE
Fixed fulltest() debug output of target string

### DIFF
--- a/util.c
+++ b/util.c
@@ -647,8 +647,6 @@ bool fulltest(const unsigned char *hash, const unsigned char *target)
 		uint32_t h32tmp = htobe32(hash32[i]);
 		uint32_t t32tmp = htole32(target32[i]);
 
-		target32[i] = swab32(target32[i]);	/* for printing */
-
 		if (h32tmp > t32tmp) {
 			rc = false;
 			break;
@@ -660,6 +658,9 @@ bool fulltest(const unsigned char *hash, const unsigned char *target)
 	}
 
 	if (opt_debug) {
+		for (i = 0; i < 32/4; i++) {
+			target32[i] = swab32(target32[i]);	/* for printing */
+		}
 		hash_str = bin2hex(hash_swap, 32);
 		target_str = bin2hex(target_swap, 32);
 


### PR DESCRIPTION
In fulltest(), the test loop does a break out
of the loop as soon as it determines the result,
but fails to complete the swab32 of the entire
target string causing the target string to be
garbled if debug output is requested.
